### PR TITLE
Run micro-dev on port set by .env

### DIFF
--- a/services/listings/README.md
+++ b/services/listings/README.md
@@ -1,3 +1,18 @@
 # Listings Service v0
 
 This is a minimal listings service which stores listings in individual JSON files and serves them via the [micro](https://github.com/zeit/micro) framework.
+
+## Running the service in development
+Set the port you would like the service to run on via a .env file.
+
+In this directory, create a .env file with the following contents:
+```
+MICRO_DEV_PORT=[your port of choice]
+```
+
+For example, if you would like the service to run on port 3001, your .env would be:
+```
+MICRO_DEV_PORT=3001
+```
+
+Then, run `yarn dev` to start the service locally on `http://localhost:[your port of choice]`.

--- a/services/listings/package.json
+++ b/services/listings/package.json
@@ -27,6 +27,7 @@
     "clean": "rimraf dist",
     "build": "yarn run clean && tsc",
     "start": "yarn run build && micro",
-    "dev": "yarn run build && concurrently \"tsc --watch\" \"micro-dev\""
+    "dev": "yarn run build && concurrently \"tsc --watch\" \"env $(cat .env | xargs) yarn micro-dev\"",
+    "micro-dev": "micro-dev -p $MICRO_DEV_PORT"
   }
 }


### PR DESCRIPTION
When `micro-dev` runs, it will try to use port 3000, and if that port is occupied it will use a random port. The public app uses port 3000, which is the default for Next.js apps, so if we run the listing service alongside the public app, `micro-dev` will see that port 3000 is busy and will use a random port. This makes it a little extra work to use the listing service from the public app, because you would have to update the listing service's port number in the API call every time you restarted the listing service. Being able to set `micro-dev`'s port via a local .env file will save that small extra step.