### PR TITLE
add the storybook viewport plugin and fix some (unrelated) story errors

### DIFF
--- a/shared/ui-components/.storybook/addons.js
+++ b/shared/ui-components/.storybook/addons.js
@@ -1,0 +1,1 @@
+import "@storybook/addon-viewport/register";

--- a/shared/ui-components/package.json
+++ b/shared/ui-components/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@storybook/addon-info": "^5.1.9",
+    "@storybook/addon-viewport": "^5.1.10",
     "@storybook/react": "^5.1.9",
     "@types/storybook__react": "^4.0.2",
     "awesome-typescript-loader": "^5.2.1",

--- a/shared/ui-components/src/cards/property_title_image.tsx
+++ b/shared/ui-components/src/cards/property_title_image.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
-import Link from 'next/link';
+import * as React from "react";
+import Link from "next/link";
 
 interface PropertyTitleImageProps {
-  title: String;
-  imageUrl: String;
+  title: string;
+  imageUrl: string;
   listingId: Number;
 }
 
@@ -12,7 +12,7 @@ export const PropertyTitleImage = (props: PropertyTitleImageProps) => (
     <a>
       <figure className="relative">
         {props.imageUrl && <img src={props.imageUrl} alt={props.title} />}
-        {!props.imageUrl && <div style={{height: "300px", background: "#ccc"}}></div>}
+        {!props.imageUrl && <div style={{ height: "300px", background: "#ccc" }} />}
         <figcaption className="absolute inset-x-0 bottom-0">
           <h2 className="text-white text-center text-2xl uppercase t-alt-sans mb-3">{props.title}</h2>
         </figcaption>

--- a/shared/ui-components/src/headers/hero.tsx
+++ b/shared/ui-components/src/headers/hero.tsx
@@ -1,35 +1,21 @@
-import * as React from 'react';
-import Link, { Url } from "next/link";
+import * as React from "react";
+import Link from "next/link";
 
 interface HeroProps {
   title: JSX.Element;
-  buttonTitle: String;
-  buttonLink: Url;
+  buttonTitle: string;
+  buttonLink: string;
 }
 
-const heroClasses = [
-  'bg-blue-700',
-  'py-20',
-  'px-5',
-  'text-white',
-  'text-center'
-]
+const heroClasses = ["bg-blue-700", "py-20", "px-5", "text-white", "text-center"];
 
-const buttonClasses = [
-  'bg-white',
-  'text-primary',
-  'uppercase',
-  'text-lg',
-  't-alt-sans',
-  'px-8',
-  'py-4'
-]
+const buttonClasses = ["bg-white", "text-primary", "uppercase", "text-lg", "t-alt-sans", "px-8", "py-4"];
 
 export const Hero = (props: HeroProps) => (
-  <div className={heroClasses.join(' ')}>
+  <div className={heroClasses.join(" ")}>
     <h1 className="title mb-10">{props.title}</h1>
     <Link href={props.buttonLink}>
-      <a className={buttonClasses.join(' ')}>{props.buttonTitle}</a>
+      <a className={buttonClasses.join(" ")}>{props.buttonTitle}</a>
     </Link>
   </div>
 );

--- a/shared/ui-components/stories/index.tsx
+++ b/shared/ui-components/stories/index.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { Button } from "../src/test-button/button";
-import { Header } from "../src/header/header";
+import { PageHeader } from "../src/headers/page_header";
 
 storiesOf("Button", module)
   .add("with text", () => <Button>Hello Button</Button>)
@@ -13,7 +13,4 @@ storiesOf("Button", module)
     </Button>
   ));
 
-storiesOf("Header", module)
-  .add("header", () => (
-    <Header />
-  ))
+storiesOf("Header", module).add("header", () => <PageHeader />);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,22 @@
     react-lifecycles-compat "^3.0.4"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-viewport@^5.1.10":
+  version "5.1.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-5.1.10.tgz#b29b942d330e77d412f24f0f1d6a140bfa5a7946"
+  integrity sha512-KgX0UMUAZ9w+pMOtwtHeDHU8xCP3jKYNjyswd6JX3spPZYzjI3E/qUWmvgzXyXWaNJQ8Ayxm6gVS2+uZ2875Yw==
+  dependencies:
+    "@storybook/addons" "5.1.10"
+    "@storybook/client-logger" "5.1.10"
+    "@storybook/components" "5.1.10"
+    "@storybook/core-events" "5.1.10"
+    "@storybook/theming" "5.1.10"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/addons@5.1.10":
   version "5.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.1.10.tgz#2d8d8ca20b6d9b4652744f5fc00ead483f705435"


### PR DESCRIPTION
a couple minor notes:

- the story errors were just typescript syntax that I'm not sure how we missed before, but were easy enough to fix. NB: declare things as string not String was most of them.

- I thought I added a prettier block to package.json but didn't so there's some noisy reformatting here. Will plan to address that asap.